### PR TITLE
Fix Regex for non-matching user defined datatypes

### DIFF
--- a/src/OrcaSql.Core/MetaData/DataColumn.cs
+++ b/src/OrcaSql.Core/MetaData/DataColumn.cs
@@ -32,7 +32,8 @@ namespace OrcaSql.Core.MetaData
 
             var typeNameWithoutNull = type.Replace(", not null", "").Replace(", null", "");
 
-            var match = Regex.Match(typeNameWithoutNull, "(?<=\\w+)\\((\\w+(\\(\\d+\\)*)*)\\)");
+//             var match = Regex.Match(typeNameWithoutNull, "(?<=\\w+)\\((\\w+(\\(\\d+\\)*)*)\\)");
+	    var match = Regex.Match(typeNameWithoutNull, "(?<=\\w+)\\((\\w+(\\(\\d+(.*)\\)*)*)\\)");
 
             var underlyingType = match.Success && !Regex.IsMatch(match.Groups[1].Value, "^\\d+|max$", RegexOptions.IgnoreCase) ? match.Groups[1].Value : typeNameWithoutNull;
 


### PR DESCRIPTION

Regular express 

`_var match = Regex.Match(typeNameWithoutNull, "(?<=\\w+)\\((\\w+(\\(\\d+\\)*)*)\\)");_`

not matching user defined types with underlining datatype with scale and precision

example
_post(numeric(1,0))_  matches _numeric(1_ 
instead of _numeric(1,0)_


Fix is 

`var match = Regex.Match(typeNameWithoutNull, "(?<=\\w+)\\((\\w+(\\(\\d+(.*)\\)*)*)\\)");`