### PR TITLE
Add deferred column materialization

### DIFF
--- a/src/OrcaSql.Core.Tests/Engine/Records/DeferredColumnValueTests.cs
+++ b/src/OrcaSql.Core.Tests/Engine/Records/DeferredColumnValueTests.cs
@@ -39,6 +39,7 @@ namespace OrcaSql.Core.Tests.Engine.Records
 
 			const int threadCount = 8;
 			var start = new ManualResetEventSlim(false);
+			var exceptions = new Exception[threadCount];
 			var results = new object[threadCount];
 			var threads = new Thread[threadCount];
 
@@ -47,16 +48,24 @@ namespace OrcaSql.Core.Tests.Engine.Records
 				int index = i;
 				threads[i] = new Thread(() =>
 				{
-					start.Wait();
-					results[index] = value.Force();
+					try
+					{
+						start.Wait();
+						results[index] = value.Force();
+					}
+					catch (Exception exception)
+					{
+						exceptions[index] = exception;
+					}
 				});
 				threads[i].Start();
 			}
 
 			start.Set();
-			foreach (var thread in threads)
-				thread.Join();
+			for (int i = 0; i < threads.Length; i++)
+				Assert.IsTrue(threads[i].Join(TimeSpan.FromSeconds(5)), "Worker thread {0} timed out.", i);
 
+			Assert.IsTrue(exceptions.All(x => x == null), string.Join(Environment.NewLine, exceptions.Where(x => x != null)));
 			Assert.IsTrue(results.All(x => (string)x == "1,2,3"));
 			Assert.AreEqual(1, proxy.Reads);
 			Assert.AreEqual(1, sqlType.Materializations);
@@ -73,6 +82,49 @@ namespace OrcaSql.Core.Tests.Engine.Records
 
 			Assert.AreEqual("", value.Force());
 			Assert.AreEqual(1, sqlType.Materializations);
+		}
+
+		[Test]
+		public void IsValueCreatedReflectsMaterializationState()
+		{
+			var value = new DeferredColumnValue(new CountingProxy(new byte[] { 1, 2, 3 }), new CountingSqlType());
+
+			Assert.IsFalse(value.IsValueCreated);
+
+			value.Force();
+
+			Assert.IsTrue(value.IsValueCreated);
+		}
+
+		[Test]
+		public void ForceCachesAndRethrowsFactoryException()
+		{
+			// A factory failure must be captured once and replayed on every subsequent call,
+			// matching Lazy<T> ExecutionAndPublication semantics. The read must not be retried.
+			var proxy = new ThrowingProxy();
+			var value = new DeferredColumnValue(proxy, new CountingSqlType());
+
+			var first = Assert.Throws<InvalidOperationException>(() => value.Force());
+			var second = Assert.Throws<InvalidOperationException>(() => value.Force());
+
+			Assert.AreSame(first, second);
+			Assert.AreEqual(1, proxy.Reads);
+			Assert.IsFalse(value.IsValueCreated);
+		}
+
+		[Test]
+		public void ForceRejectsRecursiveMaterialization()
+		{
+			DeferredColumnValue value = null;
+			var proxy = new CountingProxy(new byte[] { 1, 2, 3 });
+			value = new DeferredColumnValue(proxy, new ReentrantSqlType(() => value.Force()));
+
+			var first = Assert.Throws<InvalidOperationException>(() => value.Force());
+			var second = Assert.Throws<InvalidOperationException>(() => value.Force());
+
+			Assert.AreSame(first, second);
+			Assert.AreEqual(1, proxy.Reads);
+			Assert.IsFalse(value.IsValueCreated);
 		}
 
 		[Test]
@@ -122,6 +174,21 @@ namespace OrcaSql.Core.Tests.Engine.Records
 			}
 		}
 
+		private sealed class ThrowingProxy : IVariableLengthDataProxy
+		{
+			private readonly object _lock = new object();
+
+			public int Reads { get; private set; }
+
+			public IEnumerable<byte> GetBytes()
+			{
+				lock (_lock)
+					Reads++;
+
+				throw new InvalidOperationException("boom");
+			}
+		}
+
 		private sealed class CountingSqlType : ISqlType
 		{
 			private readonly object _lock = new object();
@@ -136,6 +203,29 @@ namespace OrcaSql.Core.Tests.Engine.Records
 				lock (_lock)
 					Materializations++;
 				return string.Join(",", value);
+			}
+
+			public object GetDefaultValue(SysDefaultConstraint columnConstraint)
+			{
+				return null;
+			}
+		}
+
+		private sealed class ReentrantSqlType : ISqlType
+		{
+			private readonly Func<object> _force;
+
+			public ReentrantSqlType(Func<object> force)
+			{
+				_force = force;
+			}
+
+			public bool IsVariableLength => true;
+			public short? FixedLength => null;
+
+			public object GetValue(byte[] value)
+			{
+				return _force();
 			}
 
 			public object GetDefaultValue(SysDefaultConstraint columnConstraint)

--- a/src/OrcaSql.Core.Tests/Engine/Records/DeferredColumnValueTests.cs
+++ b/src/OrcaSql.Core.Tests/Engine/Records/DeferredColumnValueTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using OrcaSql.Core.Engine.Records;
+using OrcaSql.Core.Engine.Records.VariableLengthDataProxies;
+using OrcaSql.Core.Engine.SqlTypes;
+using OrcaSql.Core.MetaData;
+using OrcaSql.Core.MetaData.DMVs;
+
+namespace OrcaSql.Core.Tests.Engine.Records
+{
+	[TestFixture]
+	public class DeferredColumnValueTests
+	{
+		[Test]
+		public void ForceReadsAndMaterializesOnce()
+		{
+			var proxy = new CountingProxy(new byte[] { 1, 2, 3 });
+			var sqlType = new CountingSqlType();
+			var value = new DeferredColumnValue(proxy, sqlType);
+
+			Assert.AreEqual("1,2,3", value.Force());
+			Assert.AreEqual("1,2,3", value.Force());
+			Assert.AreEqual(1, proxy.Reads);
+			Assert.AreEqual(1, sqlType.Materializations);
+		}
+
+		[Test]
+		public void ForceMaterializesOnceUnderContention()
+		{
+			// A deliberately slow read widens the race window so that a non-thread-safe
+			// implementation would let multiple threads enter the factory and read more
+			// than once. Correct ExecutionAndPublication semantics keep this at exactly one.
+			var proxy = new CountingProxy(new byte[] { 1, 2, 3 }) { DelayMs = 50 };
+			var sqlType = new CountingSqlType();
+			var value = new DeferredColumnValue(proxy, sqlType);
+
+			const int threadCount = 8;
+			var start = new ManualResetEventSlim(false);
+			var results = new object[threadCount];
+			var threads = new Thread[threadCount];
+
+			for (int i = 0; i < threadCount; i++)
+			{
+				int index = i;
+				threads[i] = new Thread(() =>
+				{
+					start.Wait();
+					results[index] = value.Force();
+				});
+				threads[i].Start();
+			}
+
+			start.Set();
+			foreach (var thread in threads)
+				thread.Join();
+
+			Assert.IsTrue(results.All(x => (string)x == "1,2,3"));
+			Assert.AreEqual(1, proxy.Reads);
+			Assert.AreEqual(1, sqlType.Materializations);
+		}
+
+		[Test]
+		public void ForceTreatsMissingBytesAsEmpty()
+		{
+			// GetBytes() may legitimately return null; the value must materialize from an
+			// empty buffer rather than throwing.
+			var proxy = new CountingProxy(null);
+			var sqlType = new CountingSqlType();
+			var value = new DeferredColumnValue(proxy, sqlType);
+
+			Assert.AreEqual("", value.Force());
+			Assert.AreEqual(1, sqlType.Materializations);
+		}
+
+		[Test]
+		public void ConstructorRejectsNullArguments()
+		{
+			Assert.Throws<ArgumentNullException>(() => new DeferredColumnValue(null, new CountingSqlType()));
+			Assert.Throws<ArgumentNullException>(() => new DeferredColumnValue(new CountingProxy(new byte[0]), null));
+		}
+
+		[Test]
+		public void RowAccessForcesDeferredValuesButRawAccessDoesNot()
+		{
+			var column = new DataColumn("Payload", "varchar(max)");
+			var row = new DataRow(new[] { column });
+			var deferred = new DeferredColumnValue(new CountingProxy(new byte[] { 65 }), new CountingSqlType());
+
+			row[column] = deferred;
+
+			Assert.AreSame(deferred, row.GetRawValue(column));
+			Assert.AreEqual("65", row[column]);
+			Assert.AreEqual("65", row.Field<string>("Payload"));
+		}
+
+		private sealed class CountingProxy : IVariableLengthDataProxy
+		{
+			private readonly byte[] _bytes;
+			private readonly object _lock = new object();
+
+			public CountingProxy(byte[] bytes)
+			{
+				_bytes = bytes;
+			}
+
+			public int DelayMs { get; set; }
+
+			public int Reads { get; private set; }
+
+			public IEnumerable<byte> GetBytes()
+			{
+				if (DelayMs > 0)
+					Thread.Sleep(DelayMs);
+
+				lock (_lock)
+					Reads++;
+
+				return _bytes;
+			}
+		}
+
+		private sealed class CountingSqlType : ISqlType
+		{
+			private readonly object _lock = new object();
+
+			public int Materializations { get; private set; }
+
+			public bool IsVariableLength => true;
+			public short? FixedLength => null;
+
+			public object GetValue(byte[] value)
+			{
+				lock (_lock)
+					Materializations++;
+				return string.Join(",", value);
+			}
+
+			public object GetDefaultValue(SysDefaultConstraint columnConstraint)
+			{
+				return null;
+			}
+		}
+	}
+}

--- a/src/OrcaSql.Core.Tests/Features/LobTypes/VarcharMaxTests.cs
+++ b/src/OrcaSql.Core.Tests/Features/LobTypes/VarcharMaxTests.cs
@@ -1,7 +1,9 @@
+using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Linq;
 using NUnit.Framework;
 using OrcaSql.Core.Engine;
+using OrcaSql.Core.MetaData;
 using OrcaSql.Core.Tests.SqlServerVersion;
 
 namespace OrcaSql.Core.Tests.Features.LobTypes
@@ -113,6 +115,26 @@ namespace OrcaSql.Core.Tests.Features.LobTypes
 				var rows = scanner.ScanTable("VarcharMaxTest20000000").ToList();
 
 				Assert.AreEqual("".PadLeft(20000000, 'A'), rows[0].Field<string>("A"));
+			});
+		}
+
+		[SqlServerTest]
+		public void VarcharMaxDeferred(DatabaseVersion version)
+		{
+			// End-to-end: a real off-row varchar(MAX) value scanned with deferral on must
+			// come back as an unmaterialized IDeferredValue, and forcing it (directly or
+			// transparently via the row accessors) must yield the real value.
+			RunDatabaseTest(version, db =>
+			{
+				var scanner = new DataScanner(db);
+				var rows = scanner.ScanTable("VarcharMaxTest40201", null, true, new HashSet<string> { "A" }).ToList();
+
+				var raw = rows[0].GetRawValue("A");
+				Assert.IsInstanceOf<IDeferredValue>(raw, "Deferred column should not be materialized until forced.");
+
+				var expected = "".PadLeft(40201, 'A');
+				Assert.AreEqual(expected, ((IDeferredValue)raw).Force());
+				Assert.AreEqual(expected, rows[0].Field<string>("A"));
 			});
 		}
 

--- a/src/OrcaSql.Core.Tests/MetaData/DataExtractorHelperTests.cs
+++ b/src/OrcaSql.Core.Tests/MetaData/DataExtractorHelperTests.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using OrcaSql.Core.MetaData;
+
+namespace OrcaSql.Core.Tests.MetaData
+{
+	[TestFixture]
+	public class DataExtractorHelperTests
+	{
+		[Test]
+		public void ShouldDeferMatchesColumnNamesCaseInsensitively()
+		{
+			var column = new DataColumn("Payload", "varchar(max)");
+			var row = new DataRow(new[] { column });
+			var helper = new DataExtractorHelper(row, new HashSet<string> { "payload" });
+
+			Assert.IsTrue(helper.ShouldDefer(column));
+		}
+
+		[Test]
+		public void ConstructorRejectsUnknownDeferredColumns()
+		{
+			var row = new DataRow(new[] { new DataColumn("Payload", "varchar(max)") });
+
+			Assert.Throws<ArgumentException>(() => new DataExtractorHelper(row, new HashSet<string> { "Missing" }));
+		}
+
+		[Test]
+		public void ConstructorRejectsNonVariableDeferredColumns()
+		{
+			var row = new DataRow(new[] { new DataColumn("Id", "int") });
+
+			Assert.Throws<ArgumentException>(() => new DataExtractorHelper(row, new HashSet<string> { "Id" }));
+		}
+
+		[Test]
+		public void ConstructorRejectsSparseDeferredColumns()
+		{
+			var column = new DataColumn("SparsePayload", "varchar(max)") { IsSparse = true };
+			var row = new DataRow(new[] { column });
+
+			Assert.Throws<ArgumentException>(() => new DataExtractorHelper(row, new HashSet<string> { "SparsePayload" }));
+		}
+
+		[Test]
+		public void ConstructorRejectsComputedDeferredColumns()
+		{
+			var row = new DataRow(new[] { new DataColumn("Calc", "Computed") });
+
+			Assert.Throws<ArgumentException>(() => new DataExtractorHelper(row, new HashSet<string> { "Calc" }));
+		}
+	}
+}

--- a/src/OrcaSql.Core/Engine/DataScanner.cs
+++ b/src/OrcaSql.Core/Engine/DataScanner.cs
@@ -19,9 +19,19 @@ namespace OrcaSql.Core.Engine
 		/// </summary>
 		public IEnumerable<Row> ScanTable(string tableName, int? schemaId = null, bool isSysTable = true)
 		{
+			return ScanTable(tableName, schemaId, isSysTable, null);
+		}
+
+		/// <summary>
+		/// Will scan any table - heap or clustered - and return an IEnumerable of generic rows with data & schema.
+		/// Deferred columns are materialized on first read.
+		/// </summary>
+		public IEnumerable<Row> ScanTable(string tableName, int? schemaId, bool isSysTable,
+			ISet<string> deferredColumns)
+		{
 			var schema = MetaData.GetEmptyDataRow(tableName, schemaId);
 
-			return ScanTable(tableName, schema, isSysTable);
+			return ScanTable(tableName, schema, isSysTable, deferredColumns);
 		}
 
         public DataRow GetEmptyDataRow(string tableName, int? schemaId = null)
@@ -66,7 +76,8 @@ namespace OrcaSql.Core.Engine
 			}
 		}
 
-		private IEnumerable<Row> ScanTable(string tableName, Row schema, bool isSysTable = true)
+		private IEnumerable<Row> ScanTable(string tableName, Row schema, bool isSysTable = true,
+			ISet<string> deferredColumns = null)
 		{
 			// Get object
 			var tableObject = Database.BaseTables.SysSchObjs
@@ -86,10 +97,11 @@ namespace OrcaSql.Core.Engine
 				throw new ArgumentException("Table has no partitions.");
 
 			// Loop all partitions and return results one by one
-			return partitions.SelectMany(partition => ScanPartition(partition.PartitionID, partition.PartitionNumber, schema, isSysTable));
+			return partitions.SelectMany(partition => ScanPartition(partition.PartitionID, partition.PartitionNumber, schema, isSysTable, deferredColumns));
 		}
 
-		private IEnumerable<Row> ScanPartition(long partitionID, int partitionNumber, Row schema, bool isSysTable = true)
+		private IEnumerable<Row> ScanPartition(long partitionID, int partitionNumber, Row schema, bool isSysTable = true,
+			ISet<string> deferredColumns = null)
 		{
 			// Lookup partition
 			var partition = Database.Dmvs.Partitions
@@ -117,7 +129,7 @@ namespace OrcaSql.Core.Engine
 
             var defaultConstraints = isSysTable ? null : Database.Dmvs.SysDefaultConstraints.Where(x => x.ParentObjectId == partition.ObjectID).ToArray();
 
-            var schemaWrapper = new DataExtractorHelper(schema, Database.Dmvs, null, partitionColumns, defaultConstraints);
+            var schemaWrapper = new DataExtractorHelper(schema, Database.Dmvs, null, partitionColumns, defaultConstraints, deferredColumns);
 
             // Heap tables won't have root pages, thus we can check whether a root page is defined for the HOBT allocation unit
             if (au.RootPagePointer != PagePointer.Zero && useClusteredIndex)

--- a/src/OrcaSql.Core/Engine/Records/DeferredColumnValue.cs
+++ b/src/OrcaSql.Core/Engine/Records/DeferredColumnValue.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using OrcaSql.Core.Engine.Records.VariableLengthDataProxies;
 using OrcaSql.Core.Engine.SqlTypes;
@@ -13,26 +15,121 @@ namespace OrcaSql.Core.Engine.Records
     /// a subset of rows or columns. Buffering unforced rows still retains each value's physical
     /// data proxy until the row is collected.
     /// </summary>
+    /// <remarks>
+    /// Materialization is performed at most once and is safe to call from multiple threads
+    /// concurrently. If the value factory throws, the failure is captured and re-thrown on
+    /// every subsequent <see cref="Force"/> call, matching the exception-caching semantics of
+    /// <see cref="Lazy{T}"/> with <see cref="LazyThreadSafetyMode.ExecutionAndPublication"/>.
+    /// </remarks>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public sealed class DeferredColumnValue : IDeferredValue
     {
-        private readonly Lazy<object> _value;
+        // State machine values guarding the single materialization. _state is read with
+        // Volatile.Read on the fast path so that the corresponding _value / _exception write
+        // (which happens-before the matching Volatile.Write) is guaranteed to be visible.
+        private const int StateUninitialized = 0;
+        private const int StateInitialized = 1;
+        private const int StateFailed = 2;
+        private const int StateInitializing = 3;
+
+        private readonly object _sync = new object();
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private Func<object> _valueFactory;
+
+        private object _value;
+        private ExceptionDispatchInfo _exception;
+        private int _state;
 
         public DeferredColumnValue(IVariableLengthDataProxy proxy, ISqlType sqlType)
         {
             if (proxy == null) throw new ArgumentNullException(nameof(proxy));
             if (sqlType == null) throw new ArgumentNullException(nameof(sqlType));
 
-            _value = new Lazy<object>(() =>
+            _valueFactory = () =>
             {
                 var data = proxy.GetBytes()?.ToArray();
                 return sqlType.GetValue(data ?? new byte[0]);
-            }, LazyThreadSafetyMode.ExecutionAndPublication);
+            };
         }
+
+        /// <summary>True once the value has been successfully materialized.</summary>
+        public bool IsValueCreated => Volatile.Read(ref _state) == StateInitialized;
 
         /// <summary>Read and materialize the column value, caching the result.</summary>
         public object Force()
         {
-            return _value.Value;
+            var state = Volatile.Read(ref _state);
+
+            if (state == StateInitialized)
+                return _value;
+
+            if (state == StateFailed)
+                return ThrowCachedException();
+
+            lock (_sync)
+            {
+                state = _state;
+
+                if (state == StateInitialized)
+                    return _value;
+
+                if (state == StateFailed)
+                    return ThrowCachedException();
+
+                if (state == StateInitializing)
+                    throw new InvalidOperationException("Value factory attempted to recursively materialize this deferred value.");
+
+                Volatile.Write(ref _state, StateInitializing);
+
+                try
+                {
+                    _value = _valueFactory();
+                    Volatile.Write(ref _state, StateInitialized);
+
+                    return _value;
+                }
+                catch (Exception exception)
+                {
+                    _exception = ExceptionDispatchInfo.Capture(exception);
+                    Volatile.Write(ref _state, StateFailed);
+
+                    throw;
+                }
+                finally
+                {
+                    _valueFactory = null;
+                }
+            }
+        }
+
+        private object ThrowCachedException()
+        {
+            _exception.Throw();
+
+            // Unreachable: ExceptionDispatchInfo.Throw always throws. Present only to satisfy
+            // the compiler's definite-return analysis.
+            throw new InvalidOperationException("Cached exception failed to re-throw.");
+        }
+
+        private string DebuggerDisplay
+        {
+            get
+            {
+                switch (Volatile.Read(ref _state))
+                {
+                    case StateUninitialized:
+                        return "Not materialized";
+                    case StateInitialized:
+                        return $"Materialized: {(_value == null ? "null" : _value.GetType().Name)}";
+                    case StateFailed:
+                        return $"Failed: {_exception?.SourceException.GetType().Name}";
+                    case StateInitializing:
+                        return "Materializing";
+                    default:
+                        return "Unknown state";
+                }
+            }
         }
     }
 }

--- a/src/OrcaSql.Core/Engine/Records/DeferredColumnValue.cs
+++ b/src/OrcaSql.Core/Engine/Records/DeferredColumnValue.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using System.Threading;
+using OrcaSql.Core.Engine.Records.VariableLengthDataProxies;
+using OrcaSql.Core.Engine.SqlTypes;
+using OrcaSql.Core.MetaData;
+
+namespace OrcaSql.Core.Engine.Records
+{
+    /// <summary>
+    /// A column value whose physical bytes are not read until <see cref="Force"/> is called.
+    /// This is useful for streaming large off-row values when a caller only needs to inspect
+    /// a subset of rows or columns. Buffering unforced rows still retains each value's physical
+    /// data proxy until the row is collected.
+    /// </summary>
+    public sealed class DeferredColumnValue : IDeferredValue
+    {
+        private readonly Lazy<object> _value;
+
+        public DeferredColumnValue(IVariableLengthDataProxy proxy, ISqlType sqlType)
+        {
+            if (proxy == null) throw new ArgumentNullException(nameof(proxy));
+            if (sqlType == null) throw new ArgumentNullException(nameof(sqlType));
+
+            _value = new Lazy<object>(() =>
+            {
+                var data = proxy.GetBytes()?.ToArray();
+                return sqlType.GetValue(data ?? new byte[0]);
+            }, LazyThreadSafetyMode.ExecutionAndPublication);
+        }
+
+        /// <summary>Read and materialize the column value, caching the result.</summary>
+        public object Force()
+        {
+            return _value.Value;
+        }
+    }
+}

--- a/src/OrcaSql.Core/Engine/Records/Parsers/CompressedRecordEntityParser.cs
+++ b/src/OrcaSql.Core/Engine/Records/Parsers/CompressedRecordEntityParser.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using OrcaSql.Core.Engine.Pages;
+using OrcaSql.Core.Engine.Records;
 using OrcaSql.Core.Engine.Records.VariableLengthDataProxies;
 using OrcaSql.Core.Engine.SqlTypes;
 using OrcaSql.Core.MetaData;
@@ -32,8 +33,13 @@ namespace OrcaSql.Core.Engine.Records.Parsers
 
 					if (dataProxy == null)
 						dataRow[col] = null;
+					else if (schema.ShouldDefer(col))
+						dataRow[col] = new DeferredColumnValue(dataProxy, sqlType);
 					else
-						dataRow[col] = sqlType.GetValue(dataProxy.GetBytes().ToArray());
+					{
+						var data = dataProxy.GetBytes()?.ToArray();
+						dataRow[col] = sqlType.GetValue(data ?? new byte[0]);
+					}
 
 					columnIndex++;
 				}

--- a/src/OrcaSql.Core/Engine/Records/Parsers/PrimaryRecordEntityParser.cs
+++ b/src/OrcaSql.Core/Engine/Records/Parsers/PrimaryRecordEntityParser.cs
@@ -70,8 +70,13 @@ namespace OrcaSql.Core.Engine.Records.Parsers
                                     // variable length columns, the value is empty by definition (that is, 0 bytes, but not null).
                                     if (variableColumnIndex < record.NumberOfVariableLengthColumns)
                                     {
-                                        var data = record.VariableLengthColumnData[variableColumnIndex].GetBytes()?.ToArray();
-                                        columnValue = sqlType.GetValue(data ?? new byte[0]);
+                                        if (schema.ShouldDefer(col))
+                                            columnValue = new DeferredColumnValue(record.VariableLengthColumnData[variableColumnIndex], sqlType);
+                                        else
+                                        {
+                                            var data = record.VariableLengthColumnData[variableColumnIndex].GetBytes()?.ToArray();
+                                            columnValue = sqlType.GetValue(data ?? new byte[0]);
+                                        }
                                     }
                                     else
                                         columnValue = sqlType.GetValue(new byte[0]);

--- a/src/OrcaSql.Core/MetaData/DataExtractorHelper.cs
+++ b/src/OrcaSql.Core/MetaData/DataExtractorHelper.cs
@@ -1,5 +1,6 @@
 using OrcaSql.Core.Engine.SqlTypes;
 using OrcaSql.Core.MetaData.DMVs;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -11,7 +12,7 @@ namespace OrcaSql.Core.MetaData
         private readonly Dictionary<int, SysDefaultConstraint> _defaultConstraints;
         private readonly Dictionary<int, object> _cachedDefaultValues;
 
-        private DataExtractorHelper(IReadOnlyCollection<DataColumn> sourceColumns, DmvGenerator dmvGenerator, SystemInternalsPartitionColumn[] partitionColumns, SysDefaultConstraint[] defaultConstraints)
+        private DataExtractorHelper(IReadOnlyCollection<DataColumn> sourceColumns, DmvGenerator dmvGenerator, SystemInternalsPartitionColumn[] partitionColumns, SysDefaultConstraint[] defaultConstraints, ISet<string> deferredColumns)
         {
             _cachedDefaultValues = new Dictionary<int, object>();
             var newOrderedColumns = new List<DataColumn>();
@@ -30,6 +31,8 @@ namespace OrcaSql.Core.MetaData
             newOrderedColumns.AddRange(columns);
 
             Schema = new Schema(newOrderedColumns);
+            DeferredColumns = NormalizeDeferredColumns(deferredColumns);
+            ValidateDeferredColumns(newOrderedColumns);
 
             BitColumnsCount = newOrderedColumns.Count(x => x.UnderlyingType == ColumnType.Bit);
 
@@ -56,15 +59,56 @@ namespace OrcaSql.Core.MetaData
 
         public Dictionary<string, int> NonSparseIndexes { get; }
 
+        public ISet<string> DeferredColumns { get; }
+
+        public bool ShouldDefer(DataColumn column)
+        {
+            return DeferredColumns != null && DeferredColumns.Contains(column.Name);
+        }
+
         public DataExtractorHelper(Row dataRow, DmvGenerator dmvGenerator, IndexColumn[] clusteredIndexColumns,
-            SystemInternalsPartitionColumn[] partitionColumns, SysDefaultConstraint[] defaultConstraints) : this(dataRow.Columns, dmvGenerator, partitionColumns, defaultConstraints)
+            SystemInternalsPartitionColumn[] partitionColumns, SysDefaultConstraint[] defaultConstraints)
+            : this(dataRow, dmvGenerator, clusteredIndexColumns, partitionColumns, defaultConstraints, null)
+        {
+        }
+
+        public DataExtractorHelper(Row dataRow, DmvGenerator dmvGenerator, IndexColumn[] clusteredIndexColumns,
+            SystemInternalsPartitionColumn[] partitionColumns, SysDefaultConstraint[] defaultConstraints, ISet<string> deferredColumns) : this(dataRow.Columns, dmvGenerator, partitionColumns, defaultConstraints, deferredColumns)
         {
             this._dataRow = dataRow;
         }
 
-        public DataExtractorHelper(Row dataRow) : this(dataRow.Columns, null, null, null)
+        public DataExtractorHelper(Row dataRow) : this(dataRow, null)
+        {
+        }
+
+        public DataExtractorHelper(Row dataRow, ISet<string> deferredColumns) : this(dataRow.Columns, null, null, null, deferredColumns)
         {
             this._dataRow = dataRow;
+        }
+
+        private static ISet<string> NormalizeDeferredColumns(ISet<string> deferredColumns)
+        {
+            return deferredColumns == null || deferredColumns.Count == 0
+                ? null
+                : new HashSet<string>(deferredColumns, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private void ValidateDeferredColumns(IEnumerable<DataColumn> columns)
+        {
+            if (DeferredColumns == null)
+                return;
+
+            var columnByName = columns.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var deferredColumn in DeferredColumns)
+            {
+                if (!columnByName.TryGetValue(deferredColumn, out var column))
+                    throw new ArgumentException("Deferred column '" + deferredColumn + "' does not exist.");
+
+                if (!column.IsVariableLength || column.IsSparse || column.UnderlyingType == ColumnType.Computed)
+                    throw new ArgumentException("Deferred column '" + deferredColumn + "' is not a deferrable variable-length column.");
+            }
         }
 
         public override Row NewRow()

--- a/src/OrcaSql.Core/MetaData/IDeferredValue.cs
+++ b/src/OrcaSql.Core/MetaData/IDeferredValue.cs
@@ -1,0 +1,10 @@
+namespace OrcaSql.Core.MetaData
+{
+    /// <summary>
+    /// Represents a row value that can be materialized on demand.
+    /// </summary>
+    public interface IDeferredValue
+    {
+        object Force();
+    }
+}

--- a/src/OrcaSql.Core/MetaData/Row.cs
+++ b/src/OrcaSql.Core/MetaData/Row.cs
@@ -47,22 +47,60 @@ namespace OrcaSql.Core.MetaData
 			
 			if(u != null)
 			{
-				if (!data.ContainsKey(name) || data[name] == null)
+				if (!data.TryGetValue(name, out var value))
 					return default(T);
 
-				return (T)Convert.ChangeType(data[name], u);
+				value = ForceDeferredValue(value);
+
+				if (value == null)
+					return default(T);
+
+				if (value is T typedNullableValue)
+					return typedNullableValue;
+
+				return (T)Convert.ChangeType(value, u);
 			}
 
 			// This is ugly, but fast as columns will practically always be present.
 			// Exceptions are... The exception.
 			try
 			{
-				return (T)Convert.ChangeType(data[name], t);
+				var value = GetValue(name);
+
+				if (value is T typedValue)
+					return typedValue;
+
+				return (T)Convert.ChangeType(value, t);
 			}
 			catch (KeyNotFoundException)
 			{
 				return (T)Convert.ChangeType(null, t);
 			}
+		}
+
+		public object GetRawValue(string name)
+		{
+			EnsureColumnExists(name);
+
+			return data.TryGetValue(name, out var value) ? value : null;
+		}
+
+		public object GetRawValue(DataColumn col)
+		{
+			return GetRawValue(col.Name);
+		}
+
+		private object GetValue(string name)
+		{
+			if (!data.TryGetValue(name, out var value))
+				throw new KeyNotFoundException();
+
+			return ForceDeferredValue(value);
+		}
+
+		private static object ForceDeferredValue(object value)
+		{
+			return value is IDeferredValue deferredValue ? deferredValue.Force() : value;
 		}
 
 		public object this[string name]
@@ -71,7 +109,7 @@ namespace OrcaSql.Core.MetaData
 			{
 				EnsureColumnExists(name);
 
-				return data.TryGetValue(name, out var value) ? value : null;
+				return data.TryGetValue(name, out var value) ? ForceDeferredValue(value) : null;
             }
 			set
 			{


### PR DESCRIPTION
Allow DataScanner callers to defer selected column values during scans so large off-row (LOB) values are only read when they are actually needed. Opt in via the new ScanTable(tableName, schemaId, isSysTable, deferredColumns) overload; the existing overloads are kept intact so the default eager-read behavior is unchanged for current callers.

Deferred columns are stored in the row as DeferredColumnValue instances (implementing IDeferredValue). Row access materializes them transparently: the indexer and Field<T> call Force() under the hood, while GetRawValue exposes the unforced wrapper for callers that want it. Materialization is cached and thread-safe via Lazy, so the physical bytes are read at most once even under concurrent access.

Deferred column names are matched case-insensitively and validated up front: unknown, fixed-length, sparse, or computed columns are rejected with an ArgumentException instead of being silently materialized.

Apply the behavior to both the primary and compressed record parsers, and align the compressed parser's empty/null byte handling with the primary path.

Tests cover cached and concurrent materialization, transparent vs raw row access, case-insensitive matching, and the validation failures.